### PR TITLE
chore: Enhance build workflow and improved .NET SDK configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,9 @@ jobs:
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v5
         with:
-          global-json-file: "./global.json"
-          cache: true
+          global-json-file: global.json
+          cache: 'true'
+          cache-dependency-path: '**/packages.lock.json'
 
       - name: Set Default TAG
         run: echo "TAG=v0.0.0" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Set TAG variable from tag
         run: echo "TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
-        if: ${{ github.event_name == 'release'  && github.ref_type == 'tag' || github.event.release.tag_name }}
+        if: github.event_name == 'release' && github.ref_type == 'tag'
 
       - name: Set VERSION variable
         run: echo "VERSION=${TAG#v}" >> $GITHUB_ENV
@@ -67,12 +67,12 @@ jobs:
 
       - name: Pack .NET Solution
         run: dotnet pack --configuration Release --no-build --output pack/
-        if: ${{ github.event_name == 'release'  && github.ref_type == 'tag' || github.event.release.tag_name }}
+        if: github.event_name == 'release' && github.ref_type == 'tag'
 
       - name: Publish .NET Solution to GitHub Packages
         continue-on-error: true
         run: dotnet nuget push pack/*.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
-        if: ${{ github.event_name == 'release'  && github.ref_type == 'tag' || github.event.release.tag_name }}
+        if: github.event_name == 'release' && github.ref_type == 'tag'
 
       - name: Store .NET Package
         uses: actions/upload-artifact@v7
@@ -81,7 +81,7 @@ jobs:
           if-no-files-found: error
           retention-days: 7
           path: pack/*.nupkg
-        if: ${{ github.event_name == 'release'  && github.ref_type == 'tag' || github.event.release.tag_name }}
+        if: github.event_name == 'release' && github.ref_type == 'tag'
 
       # Get a short-lived NuGet API key
       - name: NuGet login (OIDC → temp API key)
@@ -89,10 +89,9 @@ jobs:
         id: login
         with:
           user: ${{ secrets.NUGET_USER }}
-        if: ${{ github.event_name == 'release'  && github.ref_type == 'tag' || github.event.release.tag_name }}
+        if: github.event_name == 'release' && github.ref_type == 'tag'
 
       - name: Publish .NET Solution to NuGet.org
         continue-on-error: true
         run: dotnet nuget push pack/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source nuget
-        if: ${{ steps.login.outputs.NUGET_API_KEY != '' && github.event_name == 'release'  && github.ref_type == 'tag' || github.event.release.tag_name }}
-        
+        if: ${{ steps.login.outputs.NUGET_API_KEY != '' && github.event_name == 'release' && github.ref_type == 'tag' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
         run: echo "${VERSION}"
 
       - name: Restore .NET Packages
-        run: dotnet restore
+        run: dotnet restore --locked-mode
 
       - name: Build .NET Solution
         run: dotnet build --configuration Release --no-restore /p:Version=${VERSION}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -29,8 +31,8 @@ jobs:
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: |
-            9.x
+          global-json-file: "./global.json"
+          cache: true
 
       - name: Set Default TAG
         run: echo "TAG=v0.0.0" >> $GITHUB_ENV
@@ -78,10 +80,16 @@ jobs:
           path: pack/*.nupkg
         if: ${{ github.event_name == 'release'  && github.ref_type == 'tag' || github.event.release.tag_name }}
 
+      # Get a short-lived NuGet API key
+      - name: NuGet login (OIDC → temp API key)
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+        if: ${{ github.event_name == 'release'  && github.ref_type == 'tag' || github.event.release.tag_name }}
+
       - name: Publish .NET Solution to NuGet.org
         continue-on-error: true
-        env:
-          apikey: ${{ secrets.NUGET_ORG_KEY }}
-        run: dotnet nuget push pack/*.nupkg --api-key ${{ secrets.NUGET_ORG_KEY }} --source nuget
-        if: ${{ env.apikey != '' && github.event_name == 'release'  && github.ref_type == 'tag' || github.event.release.tag_name }}
+        run: dotnet nuget push pack/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source nuget
+        if: ${{ steps.login.outputs.NUGET_API_KEY != '' && github.event_name == 'release'  && github.ref_type == 'tag' || github.event.release.tag_name }}
         

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,9 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write
+      packages: write
     steps:
       - uses: actions/checkout@v6
         with:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
+    <!-- SourceLink -->
     <PropertyGroup>
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/escendit/tools-branding</RepositoryUrl>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
+    </PropertyGroup>
+    <!-- NuGet Restore -->
+    <PropertyGroup>
+        <RestoreLockedMode Condition="'$(CI)' == 'true'">true</RestoreLockedMode>
+        <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     </PropertyGroup>
 </Project>

--- a/src/Escendit.Tools.Branding/Escendit.Tools.Branding.csproj
+++ b/src/Escendit.Tools.Branding/Escendit.Tools.Branding.csproj
@@ -7,6 +7,7 @@
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <IsPackable>true</IsPackable>
         <IncludeBuildOutput>false</IncludeBuildOutput>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>$(NoWarn);NU5128</NoWarn>
         <Description>Provides default branding properties and assets for organization's NuGet projects.</Description>

--- a/src/Escendit.Tools.Branding/packages.lock.json
+++ b/src/Escendit.Tools.Branding/packages.lock.json
@@ -1,0 +1,22 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETStandard,Version=v2.0": {
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+      }
+    },
+    ".NETStandard,Version=v2.1": {}
+  }
+}


### PR DESCRIPTION
Closes #43

## Summary by Sourcery

Update the build workflow to use global.json-driven .NET SDK configuration and short-lived NuGet credentials for publishing.

Build:
- Configure the GitHub Actions build job with OIDC write permissions for token-based authentication.
- Switch .NET SDK setup in the build workflow to use the repository’s global.json and enable caching.
- Replace direct use of a static NuGet.org API key with NuGet/login-generated short-lived credentials when publishing release packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to use OIDC-backed publishing, job-level permissions, simplified release-tag gating, global SDK selection with caching, and locked-mode restore in CI.
  * Added CI-aware build/restore properties and a package lockfile to ensure reproducible restores.
* **New Features**
  * Projects now generate NuGet packages during build by default.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/escendit/tools-branding/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->