### PR TITLE
docs: Revise README content and improve package description and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,72 @@
 # NuGet Package: Escendit.Tools.Branding
-A NuGet package that sets the MSBuild properties such as Authors,
-PackageIcon, PackageLicenseFile, PackageReadmeFile, Copyright,
-and puts assets for Package Icon, License, and Readme files.
+
+A development-only NuGet package that automatically applies standard MSBuild branding properties
+(`Authors`, `PackageIcon`, `PackageLicenseFile`, `PackageReadmeFile`, `Copyright`) and injects the
+shared `LICENSE` and `packageIcon.png` assets into every consuming project at build time.
 
 ## Installation
-To install this package, use the NuGet Package Manager Console:
 
 ```shell
 PM> Install-Package Escendit.Tools.Branding
 ```
-Or you can search for "Escendit.Tools.Branding" in the NuGet Package Manager UI and install it from there.
 
-## Usage
-After installing the package, the MSBuild properties will be set automatically.
-You can modify the properties by updating the values in your .csproj or .vbproj file.
+Or search for `Escendit.Tools.Branding` in the NuGet Package Manager UI.
 
-For example, to set the Authors property, add the following to your .csproj or .vbproj file:
+## What It Does
+
+Once installed, the package:
+
+1. **Sets default MSBuild properties** (via `.props`) on all consuming projects:
+
+   | Property | Default value |
+   |---|---|
+   | `Authors` | `Escendit` |
+   | `Copyright` | `Copyright © Escendit GmbH` |
+   | `PackageIcon` | `packageIcon.png` |
+   | `PackageLicenseFile` | `LICENSE` |
+   | `PackageReadmeFile` | `README.md` |
+
+2. **Injects shared assets** (via `.targets`) into every consuming project's package:
+   - `LICENSE` — Apache 2.0 license file
+   - `packageIcon.png` — organization package icon
+
+Both files are linked invisibly (not shown in Solution Explorer) and packed automatically — no manual `<ItemGroup>` entries needed.
+
+## Overriding Defaults
+
+All properties can be overridden in the consuming project's `.csproj` or `.vbproj`:
 
 ```xml
 <PropertyGroup>
     <Authors>John Doe;Jane Smith</Authors>
+    <Copyright>Copyright © My Company</Copyright>
 </PropertyGroup>
 ```
 
-## MSBuild Properties
-This package sets the following MSBuild properties:
+Properties set before this package's `.props` is imported take lower precedence; properties set
+after will override it. Standard MSBuild property precedence applies.
 
-- Authors
-- PackageIcon
-- PackageLicenseFile
-- PackageReadmeFile
-- Copyright
+## Scope
 
-You can modify these properties by updating your .csproj or .vbproj file as described in the Usage section.
+This package has `DevelopmentDependency` set to `true`. It produces no runtime output — it is a
+build-time-only tool and will not appear as a dependency in the published package.
 
-## Assets
-This package includes the following assets:
+It supports single-targeting (`build/`), multi-targeting (`buildMultiTargeting/`), and transitive
+propagation (`buildTransitive/`), so projects that depend on a project using this package also
+receive the branding properties.
 
-- PackageIcon: `assets/packageIcon.png`
-- License: `assets/LICENSE`
-- Readme file: `README.md`
+## Requirements
 
-To access the assets, use the relative paths shown above.
+- .NET SDK 10.0.x (`global.json` pins `10.0.102`, rolling forward to the latest patch)
+- Targets `netstandard2.0` and `netstandard2.1`
 
 ## Contributing
-If you find a bug or have a feature request, please create an issue in the GitHub repository.
 
-To contribute code, fork the repository and submit a pull request.
-Please ensure that your code follows the project's coding standards and is thoroughly tested.
+If you find a bug or have a feature request, please open an issue in the GitHub repository.
+
+To contribute code, fork the repository and submit a pull request. Ensure your changes follow the
+project's coding standards.
 
 ## License
-Licensed under Apache License 2.0. See the LICENSE file for the complete license text.
+
+Licensed under the Apache License 2.0. See the [LICENSE](LICENSE) file for the full text.

--- a/src/Escendit.Tools.Branding/Escendit.Tools.Branding.csproj
+++ b/src/Escendit.Tools.Branding/Escendit.Tools.Branding.csproj
@@ -10,7 +10,7 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>$(NoWarn);NU5128</NoWarn>
-        <Description>Provides default branding properties and assets for organization's NuGet projects.</Description>
+        <Description>Automatically applies default branding MSBuild properties and injects shared license and icon assets into consuming NuGet packages.</Description>
         <PackageTags>branding;defaults;icons;nuget;development</PackageTags>
     </PropertyGroup>
     <ItemGroup>
@@ -26,6 +26,6 @@
         <!-- Assets -->
         <None Pack="true" PackagePath="" Include="assets/packageIcon.png" />
         <None Pack="true" PackagePath="" Include="assets/LICENSE" />
-        <None Pack="true" PackagePath="" Include="$(SolutionDir)/README.md" />
+        <None Pack="true" PackagePath="" Include="README.md" />
     </ItemGroup>
 </Project>

--- a/src/Escendit.Tools.Branding/README.md
+++ b/src/Escendit.Tools.Branding/README.md
@@ -1,0 +1,46 @@
+# Escendit.Tools.Branding
+
+A development-only NuGet package that automatically applies standard MSBuild branding properties
+and injects shared `LICENSE` and `packageIcon.png` assets into every consuming project at build time.
+
+## Installation
+
+```shell
+PM> Install-Package Escendit.Tools.Branding
+```
+
+## What It Does
+
+Once installed, the following MSBuild properties are set on your project automatically:
+
+| Property | Default value |
+|---|---|
+| `Authors` | `Escendit` |
+| `Copyright` | `Copyright © Escendit GmbH` |
+| `PackageIcon` | `packageIcon.png` |
+| `PackageLicenseFile` | `LICENSE` |
+| `PackageReadmeFile` | `README.md` |
+
+The shared `LICENSE` and `packageIcon.png` files are also injected into your package automatically
+— no manual `<ItemGroup>` entries needed.
+
+## Overriding Defaults
+
+Override any property in your `.csproj` or `.vbproj` after the package is imported:
+
+```xml
+<PropertyGroup>
+    <Authors>John Doe;Jane Smith</Authors>
+    <Copyright>Copyright © My Company</Copyright>
+</PropertyGroup>
+```
+
+## Notes
+
+- **Development dependency** — produces no runtime output; does not appear as a package dependency.
+- Supports single-targeting (`build/`), multi-targeting (`buildMultiTargeting/`), and transitive
+  propagation (`buildTransitive/`).
+
+## License
+
+Licensed under the Apache License 2.0.


### PR DESCRIPTION
Closes #45

## Summary by Sourcery

Revise and expand the package documentation for Escendit.Tools.Branding to clearly describe its behavior as a development-only branding tool and how it configures MSBuild properties and assets for consuming projects.

Documentation:
- Rewrite the root README to better explain the package’s purpose, behavior, configuration options, scope, and requirements.
- Add a package-level README under src/Escendit.Tools.Branding that documents default MSBuild properties, asset injection, override behavior, and licensing details.